### PR TITLE
test: update unit test and accepting a Date again for timestamp

### DIFF
--- a/src/crdt/crdt.spec.ts
+++ b/src/crdt/crdt.spec.ts
@@ -111,7 +111,7 @@ describe("createCRDT", () => {
 			});
 
 			const FIRST_UPDATE = {
-				timestamp: new Date(0).getTime(),
+				timestamp: new Date(0),
 				a: 1,
 			};
 

--- a/src/crdt/types.ts
+++ b/src/crdt/types.ts
@@ -18,10 +18,7 @@ export interface CreateCRDTParameters<T extends Record<string, any>> {
 export interface CRDT<T extends Record<string, any>> {
 	readonly data: T;
 	dispatch: <R = T>(
-		/**
-		 * `timestamp` should be the number of seconds since UNIX epoch
-		 */
-		updates: Partial<T> & { timestamp?: number },
+		updates: Partial<T> & { timestamp?: Date },
 		options?: DispatchOptions<T>,
 	) => R;
 	versions: T[];


### PR DESCRIPTION
- `timestamp` is fine as a `Date`? if `timestamp === updatedDates.at(-1)` then if its an array the last dispatch to get executed wins and we might lose data. if Date is initialised with UNIX epoch time then this is going to be really edge case