### PR TITLE
feat: allow skipping crdt onChange if isPersisted is specified

### DIFF
--- a/src/crdt/crdt.spec.ts
+++ b/src/crdt/crdt.spec.ts
@@ -101,25 +101,6 @@ describe("createCRDT", () => {
 			expect(latest).not.toBe(INITIAL_VALUE);
 			expect(FINAL_VALUE).toBe(latest);
 		});
-
-		it("only applies the latest updates", () => {
-			const onChange = vitest.fn();
-
-			const crdt = createCRDT({
-				initialValue: Object.create(null),
-				onChange,
-			});
-
-			const FIRST_UPDATE = {
-				timestamp: new Date(0),
-				a: 1,
-			};
-
-			crdt.dispatch(FIRST_UPDATE);
-
-			expect(onChange).not.toBeCalled();
-			expect(crdt.data).toEqual(Object.create(null));
-		});
 	});
 
 	describe("`data`", () => {

--- a/src/crdt/types.ts
+++ b/src/crdt/types.ts
@@ -23,15 +23,16 @@ export interface Dispatch<
 	C extends (next: D, previous: D) => any,
 > {
 	(
-		updates: Partial<D> & { timestamp?: Date },
+		updates: Partial<D>,
 		options?: DispatchOptions<D>,
 	): ReturnType<C> extends null | undefined ? D : ReturnType<C>;
 	(
-		updates: (state: D) => Partial<D> & { timestamp?: Date },
+		updates: (state: D) => Partial<D>,
 		options?: DispatchOptions<D>,
 	): ReturnType<C> extends null | undefined ? D : ReturnType<C>;
 }
 
 export interface DispatchOptions<T extends Record<string, any>> {
 	onChange?: (next: T, previous: T) => void;
+	isPersisted?: boolean;
 }


### PR DESCRIPTION
dispatch onChange always runs if specified. also removed timestamp, i think it will be unnecessary, subscriptions are not received from a queue